### PR TITLE
vps.premount clean exit status

### DIFF
--- a/vps.premount
+++ b/vps.premount
@@ -20,3 +20,4 @@ if type -p vzfirewall > /dev/null; then
   fi
 fi
 
+exit 0


### PR DESCRIPTION
Running vps.premount seems to work fine manually, and with vzmigrate, but I've seen failures in the environment from the init scripts, not sure why.  It seems "type" no longer supports -p then, and vzfirewall -t sometimes returns false, too (or the if/then syntax fails?)

This puts a clean exit status in vps.premount, so the failure from tests for vzfiewall presence/syntax don't carry through as the exit status for all of vps.premount.  Maybe this is "good enough" as my vzmigrate tests seemed to work, but I'll update vps.premount again if/when I can figure out what else is going on.
